### PR TITLE
Fix relative paths for npm run setup script

### DIFF
--- a/carvis-web/package.json
+++ b/carvis-web/package.json
@@ -8,7 +8,7 @@
     "build:client": "node ./tools/scripts/prod-client.js",
     "start:dev": "webpack -w & npm run build:server -- -w & nodemon -L ./dist/server/index.js",
     "build:server": "babel ./src/server -d ./dist/server --presets es2015,stage-2,es2016 --copy-files",
-    "setup": "cd ../..; git clone https://github.com/alexcstark/carvis-private-info.git; cd -; node ./tools/resolveGitIgnored.js; cd ..; rm -rf carvis-private-info",
+    "setup": "cd ../..; git clone https://github.com/alexcstark/carvis-private-info.git; cd -; node ./tools/resolveGitIgnored.js; cd ../..; rm -rf carvis-private-info",
     "test": "mocha --compilers js:babel-core/register test/index.js",
     "build": "npm run build:client; npm run build:server",
     "start": "npm run build; node ./dist/server/index.js"

--- a/carvis-web/tools/resolveGitIgnored.js
+++ b/carvis-web/tools/resolveGitIgnored.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const PRIVATE_DIR = path.join(__dirname, '/../../carvis-private-info');
+const PRIVATE_DIR = path.join(__dirname, '/../../../carvis-private-info');
 
 let fileDirectory = fs.readdirSync(PRIVATE_DIR);
 fileDirectory = fileDirectory.filter((file) => file[0] !== '.');


### PR DESCRIPTION
now `npm run setup` will properly delete the carvis-private-info repo after cloning it down